### PR TITLE
Rename pyephem to ephem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 APScheduler
 aioredis==1.3.1
 hiredis
-pyephem
+ephem
 pytz
 PyYAML

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(name="automate-home",
       ],
       packages=find_packages(exclude=[]),
       include_package_data=True,
-      install_requires=['APScheduler', 'hiredis', 'aioredis==1.3.1', 'pyephem', 'pytz', 'PyYAML']
+      install_requires=['APScheduler', 'hiredis', 'aioredis==1.3.1', 'ephem', 'pytz', 'PyYAML']
       )


### PR DESCRIPTION
[`pyephem`](https://pypi.org/project/pyephem/) is a dummy package for `ephem`.

Distributions often only have `ephem` which requires them to add a patch to build the package.