### PR TITLE
Fix ReadTheDocs build and drop leaked codecov token

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Automate home
 
 [![Tests](https://github.com/majamassarini/automate-home/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/majamassarini/automate-home/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/majamassarini/automate-home/branch/main/graph/badge.svg?token=mjBUwkmcML)](https://codecov.io/gh/majamassarini/automate-home)
+[![codecov](https://codecov.io/gh/majamassarini/automate-home/branch/main/graph/badge.svg)](https://codecov.io/gh/majamassarini/automate-home)
 [![Documentation Status](https://readthedocs.org/projects/automate-home/badge/?version=latest)](https://automate-home.readthedocs.io/en/latest/?badge=latest)
 
 ![](icon_128x128.png)


### PR DESCRIPTION
## Summary
- ReadTheDocs has no config file, so builds fail outright and the live site is stuck on a stale build (confirmed: it's missing docs content merged months ago). Added `.readthedocs.yaml` installing the package with the `doc` extra and building via Sphinx, mirroring what the `docs` job in CI already does.
- The Codecov badge in the README embedded a token (`?token=...`) in a public URL. Removed it — public repos don't need a token for the badge, and it shouldn't be exposed there.
- Double-checked the GitHub Actions tests badge already correctly points at `.github/workflows/test.yml` and renders "passing" — no change needed there.

## Test plan
- [x] Ran `sphinx-build -b html docs/source <out>` locally with the `doc` extras installed — build succeeds (same warnings as before, unrelated to this change)
- [x] Verified the Codecov badge still renders coverage (91%) without the token
- [ ] Confirm ReadTheDocs picks up the new config and produces a successful build after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5NKfwf8JEYSjERo9gCFaR